### PR TITLE
Fix no action :new for websites_path/2

### DIFF
--- a/lib/bgsite_official_web/router.ex
+++ b/lib/bgsite_official_web/router.ex
@@ -84,6 +84,8 @@ defmodule BgsiteOfficialWeb.Router do
   scope "/", BgsiteOfficialWeb do
     pipe_through [:browser,:require_authenticated_admin]
     resources "/tags", TagController, except: [:show]
+    get "/websites/new", WebsitesController, :new
+    post "/websites", WebsitesController, :create
     live "/website_live/:id", WebsiteLive
   end
 
@@ -95,7 +97,8 @@ defmodule BgsiteOfficialWeb.Router do
     post "/admin/confirm", AdminConfirmationController, :create
     get "/admin/confirm/:token", AdminConfirmationController, :confirm
     resources "/tags", TagController, only: [:show]
-    get "/websites", AdminController, :websites
+    resources "/websites", WebsitesController, except: [:create]
+    get "admin/websites", AdminController, :websites
 
     # get "/request/new", RequestController, :new
     # post "/requests", RequestController, :create


### PR DESCRIPTION
After testing it turned out that the latest PR from @N-Patarov  did not work properly - Error `no action :new for BgsiteOfficialWeb.Router.Helpers.websites_path/2`on websites?query and admin helpers dyn elm